### PR TITLE
fix mysql bug with DateTime

### DIFF
--- a/files/MAWhoNeedToRenew.php
+++ b/files/MAWhoNeedToRenew.php
@@ -4,7 +4,7 @@ require_once(ZWP_TOOLS . 'mysql.php');
 
 $nbDays = isset($_GET["nbDays"]) ? (int) $_GET["nbDays"] : 366;
 $nbDays = ($nbDays >= 1) ? $nbDays : 366;
-$until = date("o-m-d\T00:00:00", time() - $nbDays*24*3600);
+$until = new DateTime(date("o-m-d\T00:00:00", time() - $nbDays*24*3600));
 $mysqlConnector = new MysqlConnector();
 $simplifiedRegistrationEvents = $mysqlConnector->getOrderedListOfLastRegistrations($until);
 

--- a/files/mysql.php
+++ b/files/mysql.php
@@ -26,7 +26,7 @@ class MysqlConnector {
     $this->stmt = NULL;
   }
 
-  public function getOrderedListOfLastRegistrations($until) : array {
+  public function getOrderedListOfLastRegistrations(DateTime $until) : array {
     global $loggerInstance;
     try {
       $stmtGetRegistrations = $this->dbo->prepare(
@@ -37,7 +37,8 @@ class MysqlConnector {
           . ") AS tmp"
           . " WHERE lastRegistrationDate > :until"
           . " ORDER BY lastRegistrationDate");
-      $stmtGetRegistrations->bindParam(':until', $until);
+      $strDate = $until->format('Y-m-d\TH:i:s'); // This variable can't be inlined: it would yield an "Only variables should be passed by reference" error
+      $stmtGetRegistrations->bindParam(':until', $strDate);
       $stmtGetRegistrations->execute();
       $ret = array();
       while($row = $stmtGetRegistrations->fetch()){


### PR DESCRIPTION
PDO can't bind a DateTime parameter: it needs to be explicitely turned into
string. This bug hasn't been spotted earlier because this method is currently
only called by the endpoint MAWhoNeedToRenew.php which passes a string. The
caller is the class OutdatedMemberDeleter which uses a DateTime but this code
runs only once a year (when the old registrations are cleaned) and it hasn't
run yet.