### PR TITLE
feat (symfony,google service): upgrade Google API authentication method (service account)

### DIFF
--- a/symfony-server/config/services.yaml
+++ b/symfony-server/config/services.yaml
@@ -17,7 +17,6 @@ parameters:
   mailchimp.userPassword: '%env(MC_USERPWD)%'
   google.groupName: '%env(GOOGLE_GROUP_NAME)%'
   google.jsonCredentials: '%env(GOOGLE_JSON_CREDENTIALS)%'
-  google.tokenFile: '%kernel.project_dir%/var/google_tokens.json'
   notification.fromEmail: '%env(NOTIFICATION_FROM_EMAIL)%'
   notification.newcomersEmail.to: '%env(NOTIFICATION_TO_EMAIL_ABOUT_NEWCOMERS)%'
   notification.newcomersEmail.subject: '%env(NOTIFICATION_SUBJECT_EMAIL_ABOUT_NEWCOMERS)%'

--- a/symfony-server/src/Services/GoogleClientBuilder.php
+++ b/symfony-server/src/Services/GoogleClientBuilder.php
@@ -39,26 +39,6 @@ class GoogleClientBuilder {
 		$client->setAccessType('offline');
 		$client->setPrompt('select_account consent');
 
-		$tokenFile = $this->params->get('google.tokenFile');
-		if (file_exists($tokenFile)) {
-			$accessToken = json_decode(file_get_contents($tokenFile), true);
-			$client->setAccessToken($accessToken);
-		}
-
-		if ($client->isAccessTokenExpired()) {
-			if ($client->getRefreshToken()) {
-				$client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-			} else {
-				$error = "Can't get fresh Google tokens";
-				$this->logger->error($error);
-				throw new \Exception($error);
-			}
-
-			if (!file_exists(dirname($tokenFile))) {
-				mkdir(dirname($tokenFile), 0700, true);
-			}
-			file_put_contents($tokenFile, json_encode($client->getAccessToken()));
-		}
 		return $client;
 	}
 }


### PR DESCRIPTION
The aim of this PR is to be able to use a service account to query the Google API: 
- https://developers.google.com/identity/protocols/oauth2/service-account;
- https://developers.google.com/workspace/guides/create-credentials.

Code related to tokens is no longer needed.